### PR TITLE
Fixed typo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 [Unreleased]: https://github.com/chaostoolkit-incubator/chaostoolkit-istio/compare/0.1.0...HEAD
 
+-   Fixed typo
 
 ## [0.1.0][] - 2018-12-06
 

--- a/chaosistio/__init__.py
+++ b/chaosistio/__init__.py
@@ -118,5 +118,5 @@ def load_exported_activities() -> List[DiscoveredActivities]:
     """
     activities = []
     activities.extend(discover_actions("chaosistio.fault.actions"))
-    activities.extend(discover_probes("chaosisio.fault.probes"))
+    activities.extend(discover_probes("chaosistio.fault.probes"))
     return activities


### PR DESCRIPTION
Whenever you try to discover the istio probes & actions, there's a typo that causes an error
```
$ # before fix
$ chaos discover chaostoolkit-istio
[2019-07-02 12:14:42 INFO] Attempting to download and install package 'chaostoolkit-istio'
[2019-07-02 12:14:43 INFO] Package downloaded and installed in current environment
[2019-07-02 12:14:44 INFO] Discovering capabilities from chaostoolkit-istio
[2019-07-02 12:14:44 INFO] Searching for actions
[2019-07-02 12:14:44 INFO] Searching for probes
[2019-07-02 12:14:44 CRITICAL] could not import extension module 'chaosisio.fault.probes'

$ # after fix
$ chaos discover chaostoolkit-istio
[2019-07-02 12:15:53 INFO] Attempting to download and install package 'chaostoolkit-istio'
[2019-07-02 12:15:54 INFO] Package downloaded and installed in current environment
[2019-07-02 12:15:54 INFO] Discovering capabilities from chaostoolkit-istio
[2019-07-02 12:15:54 INFO] Searching for actions
[2019-07-02 12:15:54 INFO] Searching for probes
[2019-07-02 12:15:55 INFO] Discovery outcome saved in ./discovery.json
```

Signed-off-by: AlbertoSH alberto.sanz.herrero@gmail.com

