### PR TITLE
Fixes chaostoolkit-incubator/chaostoolkit-istio#3

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ $ export PRODUCT_PAGE_SERVICE_BASE_URL=$(kubectl get po -l istio=ingressgateway 
                 "arguments": {
                     "virtual_service_name": "reviews",
                     "fixed_delay": "5s",
-                    "percent": 100,
+                    "percentage": 100.0,
                     "routes": [
                         {
                             "destination": {

--- a/chaosistio/fault/actions.py
+++ b/chaosistio/fault/actions.py
@@ -181,7 +181,7 @@ def unset_fault(virtual_service_name: str, routes: List[Dict[str, str]],  # noqa
 
 def add_delay_fault(virtual_service_name: str, fixed_delay: str,
                     routes: List[Dict[str, str]],
-                    percent: float = None, ns: str = "default",
+                    percentage: float = None, ns: str = "default",
                     version: str = "networking.istio.io/v1alpha3",
                     configuration: Configuration = None,
                     secrets: Secrets = None) -> Dict[str, Any]:
@@ -195,8 +195,8 @@ def add_delay_fault(virtual_service_name: str, fixed_delay: str,
             "fixedDelay": fixed_delay
         }
     }
-    if percent is not None:
-        fault["delay"]["percent"] = percent
+    if percentage is not None:
+        fault["delay"]["percentage"] = percentage
 
     return set_fault(
         virtual_service_name, fault=fault, ns=ns, configuration=configuration,
@@ -206,7 +206,7 @@ def add_delay_fault(virtual_service_name: str, fixed_delay: str,
 
 def add_abort_fault(virtual_service_name: str, http_status: int,
                     routes: List[Dict[str, str]],
-                    percent: float = None, ns: str = "default",
+                    percentage: float = None, ns: str = "default",
                     version: str = "networking.istio.io/v1alpha3",
                     configuration: Configuration = None,
                     secrets: Secrets = None) -> Dict[str, Any]:
@@ -220,8 +220,8 @@ def add_abort_fault(virtual_service_name: str, http_status: int,
             "httpStatus": http_status
         }
     }
-    if percent is not None:
-        fault["abort"]["percent"] = percent
+    if percentage is not None:
+        fault["abort"]["percentage"] = percentage
 
     return set_fault(
         virtual_service_name, fault=fault, ns=ns, configuration=configuration,

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,6 @@
 coverage
 pycodestyle
-pytest>=2.8
+pytest==5.3.5
 pytest-cov
 pytest-sugar
 requests

--- a/tests/test_fault_actions.py
+++ b/tests/test_fault_actions.py
@@ -18,7 +18,7 @@ def test_add_fault_if_route_matches(client, get_vs):
     fault = {
         "delay": {
             "fixedDelay": "5s",
-            "percent": 100
+            "percentage": 100.0
         }
     }
 
@@ -100,7 +100,7 @@ def test_add_fault_if_route_matches(client, get_vs):
                         'fault': {
                             'delay': {
                                 'fixedDelay': '5s',
-                                'percent': 100
+                                'percentage': 100.0
                             }
                         }
                     },
@@ -138,7 +138,7 @@ def test_does_not_add_fault_if_no_route_matches(client, get_vs):
     fault = {
         "delay": {
             "fixedDelay": "5s",
-            "percent": 100
+            "percentage": 100.0
         }
     }
 
@@ -252,7 +252,7 @@ def test_remove_fault_if_route_matches(client, get_vs):
     fault = {
         "delay": {
             "fixedDelay": "5s",
-            "percent": 100
+            "percentage": 100.0
         }
     }
 
@@ -283,7 +283,7 @@ def test_remove_fault_if_route_matches(client, get_vs):
                         'fault': {
                             'delay': {
                                 'fixedDelay': '5s',
-                                'percent': 100
+                                'percentage': 100.0
                             }
                         }
                     },
@@ -421,7 +421,7 @@ def test_add_delay_fault(client, get_vs):
     call_api.return_value = (content, 200, {})
     client.return_value.call_api = call_api
 
-    res = add_delay_fault("mysvc", "5s", routes, percent=100)
+    res = add_delay_fault("mysvc", "5s", routes, percentage=100.0)
     call_api.assert_called_with(
         "/apis/networking.istio.io/v1alpha3/namespaces/default/virtualservices/mysvc",
         "PATCH",
@@ -447,7 +447,7 @@ def test_add_delay_fault(client, get_vs):
                         'fault': {
                             'delay': {
                                 'fixedDelay': '5s',
-                                'percent': 100
+                                'percentage': 100.0
                             }
                         }
                     },
@@ -534,7 +534,7 @@ def test_add_abort_fault(client, get_vs):
     call_api.return_value = (content, 200, {})
     client.return_value.call_api = call_api
 
-    res = add_abort_fault("mysvc", 404, routes, percent=100)
+    res = add_abort_fault("mysvc", 404, routes, percentage=100.0)
     call_api.assert_called_with(
         "/apis/networking.istio.io/v1alpha3/namespaces/default/virtualservices/mysvc",
         "PATCH",
@@ -560,7 +560,7 @@ def test_add_abort_fault(client, get_vs):
                         'fault': {
                             'abort': {
                                 'httpStatus': 404,
-                                'percent': 100
+                                'percentage': 100.0
                             }
                         }
                     },


### PR DESCRIPTION
remove deprecated `percent` attribute

1.4:
https://istio.io/docs/reference/config/networking/virtual-service/#HTTPFaultInjection-Abort

1.5:
https://archive.istio.io/v1.4/docs/reference/config/networking/virtual-service/#HTTPFaultInjection-Abort

also pinned pytest to 5.3.5 for now since pytest-sugar is not compatible with pytest 5.4.0+

Signed-off-by: Darin Pope <darin@planetpope.com>