### PR TITLE
fix for Percent datatype

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 [Unreleased]: https://github.com/chaostoolkit-incubator/chaostoolkit-istio/compare/0.1.3...HEAD
 
+### Changed
+
+-   fix for Percent datatype [#6][6]
+
+[6]: https://github.com/chaostoolkit-incubator/chaostoolkit-istio/pull/6
+
 ## [0.1.3][] - 2020-04-02
 
 [0.1.3]: https://github.com/chaostoolkit-incubator/chaostoolkit-istio/compare/0.1.2...0.1.3

--- a/README.md
+++ b/README.md
@@ -95,7 +95,9 @@ $ export PRODUCT_PAGE_SERVICE_BASE_URL=$(kubectl get po -l istio=ingressgateway 
                 "arguments": {
                     "virtual_service_name": "reviews",
                     "fixed_delay": "5s",
-                    "percentage": 100.0,
+                    "percentage": {
+                        "value":  100.0
+                    },
                     "routes": [
                         {
                             "destination": {

--- a/chaosistio/fault/actions.py
+++ b/chaosistio/fault/actions.py
@@ -196,7 +196,8 @@ def add_delay_fault(virtual_service_name: str, fixed_delay: str,
         }
     }
     if percentage is not None:
-        fault["delay"]["percentage"] = percentage
+        fault["delay"]["percentage"] = {}
+        fault["delay"]["percentage"]["value"] = percentage
 
     return set_fault(
         virtual_service_name, fault=fault, ns=ns, configuration=configuration,
@@ -221,7 +222,8 @@ def add_abort_fault(virtual_service_name: str, http_status: int,
         }
     }
     if percentage is not None:
-        fault["abort"]["percentage"] = percentage
+        fault["abort"]["percentage"] = {}
+        fault["abort"]["percentage"]["value"] = percentage
 
     return set_fault(
         virtual_service_name, fault=fault, ns=ns, configuration=configuration,

--- a/tests/test_fault_actions.py
+++ b/tests/test_fault_actions.py
@@ -18,7 +18,9 @@ def test_add_fault_if_route_matches(client, get_vs):
     fault = {
         "delay": {
             "fixedDelay": "5s",
-            "percentage": 100.0
+            "percentage": {
+                "value": 100.0
+            }
         }
     }
 
@@ -100,7 +102,9 @@ def test_add_fault_if_route_matches(client, get_vs):
                         'fault': {
                             'delay': {
                                 'fixedDelay': '5s',
-                                'percentage': 100.0
+                                'percentage': {
+                                    'value': 100.0
+                                }
                             }
                         }
                     },
@@ -138,7 +142,9 @@ def test_does_not_add_fault_if_no_route_matches(client, get_vs):
     fault = {
         "delay": {
             "fixedDelay": "5s",
-            "percentage": 100.0
+            "percentage": {
+                "value": 100.0
+            }
         }
     }
 
@@ -252,7 +258,9 @@ def test_remove_fault_if_route_matches(client, get_vs):
     fault = {
         "delay": {
             "fixedDelay": "5s",
-            "percentage": 100.0
+            "percentage": {
+                "value": 100.0
+            }
         }
     }
 
@@ -283,7 +291,9 @@ def test_remove_fault_if_route_matches(client, get_vs):
                         'fault': {
                             'delay': {
                                 'fixedDelay': '5s',
-                                'percentage': 100.0
+                                'percentage': {
+                                    'value': 100.0
+                                }
                             }
                         }
                     },
@@ -447,7 +457,9 @@ def test_add_delay_fault(client, get_vs):
                         'fault': {
                             'delay': {
                                 'fixedDelay': '5s',
-                                'percentage': 100.0
+                                'percentage': {
+                                    'value': 100.0
+                                }
                             }
                         }
                     },
@@ -560,7 +572,9 @@ def test_add_abort_fault(client, get_vs):
                         'fault': {
                             'abort': {
                                 'httpStatus': 404,
-                                'percentage': 100.0
+                                'percentage': {
+                                    'value': 100.0
+                                }
                             }
                         }
                     },


### PR DESCRIPTION
The fix in 0.1.3 was not correct because of the new Percent data type. Needed to add “value” to the dictionary.

Signed-off-by: Darin Pope <darin@planetpope.com>